### PR TITLE
bump node to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
       Start writing warnings at this level: ["unknown", "negligible", "low", "medium", "high", "critical"]
       Default: high
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   color: "blue"


### PR DESCRIPTION
- fix deprecation message
- via: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: Miragon/sarif-report-parse@v1.0.3. 
For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

/cc @DaAnda97 @lmoesle @alex-praschek @dominikhorn93