### PR TITLE
Update Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
       Start writing warnings at this level: ["unknown", "negligible", "low", "medium", "high", "critical"]
       Default: high
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"
 branding:
   color: "blue"


### PR DESCRIPTION
👋 Hello again 😉 

- fix deprecation message
- via: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

```
Node.js 20 actions are deprecated. 
The following actions are running on Node.js 20 and may not work as expected: Miragon/sarif-report-parse@v1.0.4. 

Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. 
Please check if updated versions of these actions are available that support Node.js 24. 

To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. 

Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. 

For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

/cc @DaAnda97 @lmoesle @alex-praschek @dominikhorn93